### PR TITLE
Migrating from trove, fixing some resource leakage in unit tests and correcting markdown errors due to new github markdown processor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+*.iml
+target

--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
 
 <img align="left" src="images/byteseek_logo_64x63.png"> 
+
 # byteseek
 byteseek is a Java library for efficiently matching patterns of bytes and searching for those patterns.  Source code can be found at Github in the [byteseek repository](https://github.com/nishihatapalmer/byteseek). Published releases of byteseek are also available on [maven central](https://search.maven.org/#search|ga|1|byteseek).  The main well-tested packages are:
 
-####Matcher
+#### Matcher
 A package which contains various types of matcher for individual bytes or sequences of them.
 * bytes - matchers (and inverted matchers) for bytes, ranges of bytes, sets, any byte, and bitmasks.
 * sequence - matchers for sequences of bytes, byte matchers, fixed gaps and sequences of sequences.  
 
-####Searcher
+#### Searcher
 A package which contains implementations of various search algorithms.  Most of them are sub-linear, which means they don't have to examine every position in an input source to find all possible matches.  All the search algorithms have been extended to work with sequences which can match more than one byte at a given position.  Any sequence search algorithm can work with any sequence matcher, no matter how it is composed.  All the search implementations are stream-friendly - the length of an input source is not required unless you explicitly want to work at the end of an input source.  
 
 * bytes - a naive searcher for byte matchers.
 * matcher - a naive searcher for any matcher.
 * sequence - various implementations of the naive search, Boyer-Moore-Horspool, Signed Horspool and Sunday QuickSearch algorithms.
 
-####IO
+#### IO
 Matchers and searchers can all work over byte arrays directly.  In order to read efficiently from any other input source,
 readers provide a consistent random-access interface over files, input streams, strings and byte arrays.  Pluggable caching strategies allow tailoring the memory and performance for different use cases.
 
@@ -24,25 +25,25 @@ This package may be generally useful, independent of byteseek matching and searc
 * reader - readers for files, input streams, strings and byte arrays, and an adapter from any reader back to an InputStream.  Readers cache the byte arrays read from the input sources using flexible caching strategies.
 * reader/cache - pluggable caching strategies for readers, including least recently added, least recently used, temporary file caches, two level caches, double caches and others.
 
-####Parser
+#### Parser
 A byte-oriented regular expression language is given to allow the easy construction of byte matchers, sequence matchers, and (eventually) finite state automata.  An abstract syntax tree is defined, so other regular expression syntaxes could be used if required.
 * regex - a parser for a byte-oriented regular expression language, which produces a byteseek abstract syntax tree.
 
-####Compiler
+#### Compiler
 A package which contains compilers for all of the matchers from an abstract syntax tree.
 * matchers - compilers from the byteseek abstract syntax tree to byte matchers and sequence matchers.
 
-##Untested
+## Untested
 Various other packages exist which are not currently tested, but will become so eventually.  These include:
 
-####Matcher
+#### Matcher
 * multisequence - algorithms for multi-sequence matching, including lists and trie structures.
 * automata - matchers for non deterministic and deterministic automata.
 
-####Searcher
+#### Searcher
 * multisequence - implementations of Set Horspool, Signed Set Horspool, Wu-Manber and Signed Wu-Manber algorithms.
 
-####Compiler
+#### Compiler
 * regex - produces full regular expressions as finite state automata from the byteseek abstract syntax tree.
 
 Regular expressions are constructed as Glushkov finite state automata, rather than the more common [Thompson construction](https://en.wikipedia.org/wiki/Thompson's_construction).  Glushkov automata are generally more compact and have no empty transitions, which can improve performance and makes them simpler to work with.
@@ -51,7 +52,7 @@ The [normal construction for Glushkov automata](https://en.wikipedia.org/wiki/Gl
 
 > "[A reexamination of the Glushkov and Thompson Constructions](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.50.5883&rank=1)", by Dora Giammarresi, Jean-Luc Ponty, Derick Wood, 1998.
 
-####Automata
+#### Automata
 * Finite state automata with flexible transitions can be constructed. 
 * Non deterministic automata can be converted into deterministic automata.
 * Trie structures are provided from multi sequences. 

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -129,9 +129,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.sf.trove4j</groupId>
-            <artifactId>trove4j</artifactId>
-            <version>3.0.3</version>
+            <groupId>org.apache.mahout</groupId>
+            <artifactId>mahout-math</artifactId>
+            <version>0.13.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/net/byteseek/io/reader/cache/AllWindowsCache.java
+++ b/src/main/java/net/byteseek/io/reader/cache/AllWindowsCache.java
@@ -31,9 +31,8 @@
 
 package net.byteseek.io.reader.cache;
 
-import gnu.trove.map.TLongObjectMap;
-import gnu.trove.map.hash.TLongObjectHashMap;
 import net.byteseek.io.reader.windows.Window;
+import org.apache.mahout.math.map.OpenLongObjectHashMap;
 
 
 /**
@@ -47,7 +46,7 @@ import net.byteseek.io.reader.windows.Window;
  */
 public final class AllWindowsCache extends AbstractFreeNotificationCache {
 
-    private final TLongObjectMap<Window> cache = new TLongObjectHashMap<Window>();
+    private final OpenLongObjectHashMap<Window> cache = new OpenLongObjectHashMap<Window>();
 
     /**
      * {@inheritDoc}

--- a/src/main/java/net/byteseek/io/reader/cache/TempFileCache.java
+++ b/src/main/java/net/byteseek/io/reader/cache/TempFileCache.java
@@ -35,10 +35,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 
-import gnu.trove.map.TLongObjectMap;
-import gnu.trove.map.hash.TLongObjectHashMap;
 import net.byteseek.io.IOUtils;
 import net.byteseek.io.reader.windows.*;
+import org.apache.mahout.math.map.AbstractLongObjectMap;
+import org.apache.mahout.math.map.OpenLongObjectHashMap;
 
 
 /**
@@ -53,7 +53,7 @@ import net.byteseek.io.reader.windows.*;
  */
 public final class TempFileCache extends AbstractFreeNotificationCache implements SoftWindowRecovery {
 
-    private final TLongObjectMap<WindowInfo> windowPositions;
+    private final AbstractLongObjectMap<WindowInfo> windowPositions;
     private final File tempDir;
     private File tempFile;
     private RandomAccessFile file;
@@ -75,7 +75,7 @@ public final class TempFileCache extends AbstractFreeNotificationCache implement
      * @throws java.lang.IllegalArgumentException if the tempdir supplied is not a directory.
      */
     public TempFileCache(final File tempDir) {
-        windowPositions = new TLongObjectHashMap<WindowInfo>();
+        windowPositions = new OpenLongObjectHashMap<WindowInfo>();
         this.tempDir = tempDir;
         if (tempDir != null && !tempDir.isDirectory()) {
             throw new IllegalArgumentException("The temp dir file supplied is not a directory: " + tempDir.getAbsolutePath());

--- a/src/main/java/net/byteseek/io/reader/cache/TopAndTailCache.java
+++ b/src/main/java/net/byteseek/io/reader/cache/TopAndTailCache.java
@@ -31,9 +31,9 @@
 
 package net.byteseek.io.reader.cache;
 
-import gnu.trove.map.TLongObjectMap;
-import gnu.trove.map.hash.TLongObjectHashMap;
 import net.byteseek.io.reader.windows.Window;
+import org.apache.mahout.math.map.AbstractLongObjectMap;
+import org.apache.mahout.math.map.OpenLongObjectHashMap;
 
 import java.io.IOException;
 import java.util.*;
@@ -58,7 +58,7 @@ import java.util.*;
  */
 public final class TopAndTailCache extends AbstractFreeNotificationCache {
 
-    private final TLongObjectMap<Window> cache;
+    private final AbstractLongObjectMap<Window> cache;
     private final List<Window> tailCacheEntries;
     private final int firstCacheSize;
     private final int secondCacheSize;
@@ -70,7 +70,7 @@ public final class TopAndTailCache extends AbstractFreeNotificationCache {
     }
 
     public TopAndTailCache(final int firstCacheSize, final int secondCacheSize) {
-        this.cache = new TLongObjectHashMap<Window>();
+        this.cache = new OpenLongObjectHashMap<Window>();
         this.tailCacheEntries = new ArrayList<Window>();
         this.firstCacheSize  = firstCacheSize;
         this.secondCacheSize = secondCacheSize;
@@ -121,7 +121,7 @@ public final class TopAndTailCache extends AbstractFreeNotificationCache {
                 final int nextToCheck = nextTailCacheToCheck;
                 final Window window = tailCacheEntries.get(nextToCheck);
                 if (window.getWindowEndPosition() < tailCacheStart) {
-                    cache.remove(window.getWindowPosition());
+                    cache.removeKey(window.getWindowPosition());
                     tailCacheEntries.remove(nextToCheck);
                     notifyWindowFree(window, this);
                 } else {

--- a/src/main/java/net/byteseek/io/reader/cache/TopAndTailFixedLengthCache.java
+++ b/src/main/java/net/byteseek/io/reader/cache/TopAndTailFixedLengthCache.java
@@ -31,9 +31,9 @@
 
 package net.byteseek.io.reader.cache;
 
-import gnu.trove.map.TLongObjectMap;
-import gnu.trove.map.hash.TLongObjectHashMap;
 import net.byteseek.io.reader.windows.Window;
+import org.apache.mahout.math.map.AbstractLongObjectMap;
+import org.apache.mahout.math.map.OpenLongObjectHashMap;
 
 /**
  * A cache which holds on to a number of bytes at the top and tail of a reader.
@@ -48,7 +48,7 @@ public final class TopAndTailFixedLengthCache extends AbstractFreeNotificationCa
 
     final long topCacheEnd;
     final long tailCacheStart;
-    final TLongObjectMap<Window> cache;
+    final AbstractLongObjectMap<Window> cache;
 
     public TopAndTailFixedLengthCache(final long length, final long topTailBytes) {
         this(length, topTailBytes, topTailBytes);
@@ -57,7 +57,7 @@ public final class TopAndTailFixedLengthCache extends AbstractFreeNotificationCa
     public TopAndTailFixedLengthCache(final long length, final long topCacheBytes, final long tailCacheBytes) {
         this.topCacheEnd    = topCacheBytes;
         this.tailCacheStart = length - tailCacheBytes - 1;
-        this.cache          = new TLongObjectHashMap<Window>();
+        this.cache          = new OpenLongObjectHashMap<Window>();
     }
 
     @Override

--- a/src/main/java/net/byteseek/io/reader/cache/TopAndTailStreamCache.java
+++ b/src/main/java/net/byteseek/io/reader/cache/TopAndTailStreamCache.java
@@ -31,9 +31,9 @@
 
 package net.byteseek.io.reader.cache;
 
-import gnu.trove.map.TLongObjectMap;
-import gnu.trove.map.hash.TLongObjectHashMap;
 import net.byteseek.io.reader.windows.Window;
+import org.apache.mahout.math.map.AbstractLongObjectMap;
+import org.apache.mahout.math.map.OpenLongObjectHashMap;
 
 import java.io.IOException;
 import java.util.*;
@@ -52,7 +52,7 @@ public final class TopAndTailStreamCache extends AbstractFreeNotificationCache {
 
     final long topCacheBytes;
     final long tailCacheBytes;
-    final TLongObjectMap<Window> cache;
+    final AbstractLongObjectMap<Window> cache;
     final List<Window> tailEntries;
     long lastSeenPosition;
 
@@ -63,7 +63,7 @@ public final class TopAndTailStreamCache extends AbstractFreeNotificationCache {
     public TopAndTailStreamCache(final long topBytes, final long tailBytes) {
         this.topCacheBytes  = topBytes;
         this.tailCacheBytes = tailBytes;
-        cache               = new TLongObjectHashMap<Window>();
+        cache               = new OpenLongObjectHashMap<Window>();
         tailEntries         = new ArrayList<Window>();
 
     }
@@ -96,7 +96,7 @@ public final class TopAndTailStreamCache extends AbstractFreeNotificationCache {
             if (removeEntry > 0) {
                 for (int i = 0; i < removeEntry; i++) {
                     final Window toRemove = tailEntries.get(i);
-                    cache.remove(toRemove.getWindowPosition());
+                    cache.removeKey(toRemove.getWindowPosition());
                     notifyWindowFree(toRemove, this);
                 }
                 tailEntries.subList(0, removeEntry).clear();

--- a/src/test/java/net/byteseek/io/reader/FileReaderTest.java
+++ b/src/test/java/net/byteseek/io/reader/FileReaderTest.java
@@ -94,20 +94,23 @@ public class FileReaderTest {
 	}
 
 	@Test
-	public void testIterateWindows() {
+	public void testIterateWindows() throws IOException {
 		FileReaderIterator ri = new FileReaderIterator("/TestASCII.txt");
 		while (ri.hasNext()) {
-			WindowReader reader = ri.next();
-			testIterateReader(reader);
+			try (WindowReader reader = ri.next()) {
+				testIterateReader(reader);
+			}
 		}
+
 	}
 
 	@Test(expected = UnsupportedOperationException.class)
-	public void testNoRemoveIterator() {
+	public void testNoRemoveIterator() throws IOException {
 		FileReaderIterator ri = new FileReaderIterator("/TestASCII.txt");
-		WindowReader reader = ri.next();
-		Iterator<Window> iterator = reader.iterator();
-		iterator.remove();
+		try(WindowReader reader = ri.next()) {
+			Iterator<Window> iterator = reader.iterator();
+			iterator.remove();
+		}
 	}
 
 	private void testIterateReader(WindowReader reader) {
@@ -125,46 +128,48 @@ public class FileReaderTest {
 	 */
 	@Test
 	public void testLength() throws IOException {
-		@SuppressWarnings("resource")
-		FileReader reader = new FileReader(getFile("/TestASCII.txt"));
-		assertEquals("length ASCII", 112280, reader.length());
-	
-		// no matter how the file reader sets its window sizes or cache strategies,
-		// it must make no difference to the total length of the data read.
-		FileReaderIterator iterator = new FileReaderIterator("/TestASCII.txt");
-		while (iterator.hasNext()) {
-			FileReader aReader = iterator.next();
-			long totalLength = 0;
-			for (Window window : aReader) {
-				totalLength += window.length();
+		FileReaderIterator iterator;
+		try (FileReader reader = new FileReader(getFile("/TestASCII.txt"))){
+			assertEquals("length ASCII", 112280, reader.length());
+
+			// no matter how the file reader sets its window sizes or cache strategies,
+			// it must make no difference to the total length of the data read.
+			iterator = new FileReaderIterator("/TestASCII.txt");
+			while (iterator.hasNext()) {
+				FileReader aReader = iterator.next();
+				long totalLength = 0;
+				for (Window window : aReader) {
+					totalLength += window.length();
+				}
+				assertEquals("sum of window lengths ASCII", 112280, totalLength);
 			}
-			assertEquals("sum of window lengths ASCII", 112280, totalLength);
+		}
+		try(FileReader reader = new FileReader(getFile("/TestASCII.zip"))) {
+			assertEquals("length ZIP", 45846, reader.length());
+
+			iterator = new FileReaderIterator("/TestASCII.zip");
+			while (iterator.hasNext()) {
+				FileReader aReader = iterator.next();
+				long totalLength = 0;
+				for (Window window : aReader) {
+					totalLength += window.length();
+				}
+				assertEquals("sum of window lengths ZIP", 45846, totalLength);
+			}
 		}
 
-		reader = new FileReader(getFile("/TestASCII.zip"));
-		assertEquals("length ZIP", 45846, reader.length());
+		try(FileReader reader = new FileReader(getFile("/TestEmpty.empty"))) {
+			assertEquals("length empty", 0, reader.length());
 
-		iterator = new FileReaderIterator("/TestASCII.zip");
-		while (iterator.hasNext()) {
-			FileReader aReader = iterator.next();
-			long totalLength = 0;
-			for (Window window : aReader) {
-				totalLength += window.length();
+			iterator = new FileReaderIterator("/TestEmpty.empty");
+			while (iterator.hasNext()) {
+				FileReader aReader = iterator.next();
+				long totalLength = 0;
+				for (Window window : aReader) {
+					totalLength += window.length();
+				}
+				assertEquals("sum of window lengths empty file", 0, totalLength);
 			}
-			assertEquals("sum of window lengths ZIP", 45846, totalLength);
-		}
-
-		reader = new FileReader(getFile("/TestEmpty.empty"));
-		assertEquals("length empty", 0, reader.length());
-
-		iterator = new FileReaderIterator("/TestEmpty.empty");
-		while (iterator.hasNext()) {
-			FileReader aReader = iterator.next();
-			long totalLength = 0;
-			for (Window window : aReader) {
-				totalLength += window.length();
-			}
-			assertEquals("sum of window lengths empty file", 0, totalLength);
 		}
 	}
 
@@ -182,16 +187,17 @@ public class FileReaderTest {
 
 		FileReaderIterator iterator = new FileReaderIterator("/TestASCII.txt");
 		while (iterator.hasNext()) {
-			FileReader reader = iterator.next();
+			try(FileReader reader = iterator.next()) {
 
-			// testReadByte known positions at and around the specified position:
-			testReadByte(reader, 112122, (byte) 0x50);
-			testReadByte(reader, 112271, (byte) 0x44);
-			testReadByte(reader, 112275, (byte) 0x6d);
-			testReadByte(reader, 112277, (byte) 0x2e);
+				// testReadByte known positions at and around the specified position:
+				testReadByte(reader, 112122, (byte) 0x50);
+				testReadByte(reader, 112271, (byte) 0x44);
+				testReadByte(reader, 112275, (byte) 0x6d);
+				testReadByte(reader, 112277, (byte) 0x2e);
 
-			// testReadByte randomly selected positions:
-			testRandomPositions("ascii file:", raf, reader, fileLength);
+				// testReadByte randomly selected positions:
+				testRandomPositions("ascii file:", raf, reader, fileLength);
+			}
 		}
 
 		raf.close();
@@ -202,17 +208,18 @@ public class FileReaderTest {
 
 		iterator = new FileReaderIterator("/TestASCII.zip");
 		while (iterator.hasNext()) {
-			FileReader reader = iterator.next();
+			try(FileReader reader = iterator.next()) {
 
-			// Test known positions at and around the specified position:
-			testReadByte(reader, 3, (byte) 0x04);
-			testReadByte(reader, 0, (byte) 0x50);
-			testReadByte(reader, 1584, (byte) 0xAA);
-			testReadByte(reader, 30359, (byte) 0x6F);
-			testReadByte(reader, 39898, (byte) 0xFB);
+				// Test known positions at and around the specified position:
+				testReadByte(reader, 3, (byte) 0x04);
+				testReadByte(reader, 0, (byte) 0x50);
+				testReadByte(reader, 1584, (byte) 0xAA);
+				testReadByte(reader, 30359, (byte) 0x6F);
+				testReadByte(reader, 39898, (byte) 0xFB);
 
-			// testReadByte randomly selected positions:
-			testRandomPositions("ascii file:", raf, reader, fileLength);
+				// testReadByte randomly selected positions:
+				testRandomPositions("ascii file:", raf, reader, fileLength);
+			}
 		}
 
 		raf.close();
@@ -244,7 +251,9 @@ public class FileReaderTest {
 
 		Iterator<FileReader> iterator = new FileReaderIterator("/TestASCII.zip");
 		while (iterator.hasNext()) {
-			testGetWindowData(iterator.next(), raf);
+			try(WindowReader wr = iterator.next()) {
+				testGetWindowData(wr, raf);
+			}
 		}
 	}
 
@@ -254,14 +263,15 @@ public class FileReaderTest {
 		RandomAccessFile raf = new RandomAccessFile(zipfile, "r");
 		Iterator<FileReader> iterator = new FileReaderIterator("/TestASCII.zip");
 		while (iterator.hasNext()) {
-			FileReader reader = iterator.next();
-			for (Window window : reader) {
-				byte[] original  = window.getArray().clone();
-				byte[] recovered = reader.reloadWindowBytes(window);
-				assertTrue("Length is enough orig=" + original.length + " win length=" + window.length() + " recovered len=" + recovered.length, recovered.length >= window.length());
-				for (int i=0; i < original.length; i++) {
-					if (original[i] != recovered[i]) {
-						fail("Bytes not the same at position " + i + " in recovered window: " + window);
+			try(FileReader reader = iterator.next()) {
+				for (Window window : reader) {
+					byte[] original = window.getArray().clone();
+					byte[] recovered = reader.reloadWindowBytes(window);
+					assertTrue("Length is enough orig=" + original.length + " win length=" + window.length() + " recovered len=" + recovered.length, recovered.length >= window.length());
+					for (int i = 0; i < original.length; i++) {
+						if (original[i] != recovered[i]) {
+							fail("Bytes not the same at position " + i + " in recovered window: " + window);
+						}
 					}
 				}
 			}
@@ -298,9 +308,11 @@ public class FileReaderTest {
 	public void testGetZeroWindow() throws Exception {
 		FileReaderIterator it = new FileReaderIterator("/TestASCII.txt");
 		while (it.hasNext()) {
-			Window window = it.next().getWindow(0);
-			assertNotNull("have window at 0: " , window);
-			assertEquals("window is at zero:", 0, window.getWindowPosition());
+			try(FileReader fr = it.next()){
+				Window window = fr.getWindow(0);
+				assertNotNull("have window at 0: ", window);
+				assertEquals("window is at zero:", 0, window.getWindowPosition());
+			}
 		}
 	}
 
@@ -308,7 +320,9 @@ public class FileReaderTest {
 	public void testGetMidWindow() throws Exception {
 		FileReaderIterator it = new FileReaderIterator("/TestASCII.txt");
 		while (it.hasNext()) {
-			assertNotNull("Have window at 512: ", it.next().getWindow(512));
+			try(FileReader fr = it.next()) {
+				assertNotNull("Have window at 512: ", fr.getWindow(512));
+			}
 		}
 	}
 
@@ -316,7 +330,9 @@ public class FileReaderTest {
 	public void testWindowAfterLength() throws Exception {
 		FileReaderIterator it = new FileReaderIterator("/TestASCII.txt");
 		while (it.hasNext()) {
-			assertNull("No window after length: ", it.next().getWindow(112281));
+			try(FileReader fr = it.next()) {
+				assertNull("No window after length: ", fr.getWindow(112281));
+			}
 		}
 	}
 
@@ -324,7 +340,9 @@ public class FileReaderTest {
 	public void testWindowLongAfterLength() throws Exception {
 		FileReaderIterator it = new FileReaderIterator("/TestASCII.txt");
 		while (it.hasNext()) {
-			assertNull("No window after length: ", it.next().getWindow(200000));
+			try(FileReader fr = it.next()) {
+				assertNull("No window after length: ", fr.getWindow(200000));
+			}
 		}
 	}
 
@@ -333,7 +351,9 @@ public class FileReaderTest {
 	public void testCreateNegativeWindow() throws Exception {
 		FileReaderIterator it = new FileReaderIterator("/TestASCII.txt");
 		while (it.hasNext()) {
-			assertNull("No window after length: ", it.next().createWindow(-1));
+			try(FileReader fr = it.next()) {
+				assertNull("No window after length: ", fr.createWindow(-1));
+			}
 		}
 	}
 
@@ -341,9 +361,11 @@ public class FileReaderTest {
 	public void testCreateZeroWindow() throws Exception {
 		FileReaderIterator it = new FileReaderIterator("/TestASCII.txt");
 		while (it.hasNext()) {
-			Window window = it.next().createWindow(0);
-			assertNotNull("have window at 0: ", window);
-			assertEquals("window is at zero:", 0, window.getWindowPosition());
+			try(FileReader fr = it.next()) {
+				Window window = fr.createWindow(0);
+				assertNotNull("have window at 0: ", window);
+				assertEquals("window is at zero:", 0, window.getWindowPosition());
+			}
 		}
 	}
 
@@ -351,7 +373,9 @@ public class FileReaderTest {
 	public void testCreateMidWindow() throws Exception {
 		FileReaderIterator it = new FileReaderIterator("/TestASCII.txt");
 		while (it.hasNext()) {
-			assertNotNull("Have window at 512: ", it.next().createWindow(512));
+			try(FileReader fr = it.next()) {
+				assertNotNull("Have window at 512: ", fr.createWindow(512));
+			}
 		}
 	}
 
@@ -359,7 +383,9 @@ public class FileReaderTest {
 	public void testCreateWindowAfterLength() throws Exception {
 		FileReaderIterator it = new FileReaderIterator("/TestASCII.txt");
 		while (it.hasNext()) {
-			assertNull("No window after length: ", it.next().createWindow(112281));
+			try(FileReader fr = it.next()) {
+				assertNull("No window after length: ", fr.createWindow(112281));
+			}
 		}
 	}
 
@@ -367,7 +393,9 @@ public class FileReaderTest {
 	public void testCreateWindowLongAfterLength() throws Exception {
 		FileReaderIterator it = new FileReaderIterator("/TestASCII.txt");
 		while (it.hasNext()) {
-			assertNull("No window after length: ", it.next().createWindow(200000));
+			try(FileReader fr = it.next()) {
+				assertNull("No window after length: ", fr.createWindow(200000));
+			}
 		}
 	}
 
@@ -375,9 +403,10 @@ public class FileReaderTest {
 	public void testSetSoftWindowRecoveryGetWindow() throws Exception {
 		FileReaderIterator it = new FileReaderIterator("/TestASCII.txt");
 		while (it.hasNext()) {
-			FileReader reader = it.next();
-			reader.useSoftWindows(true);
-			assertEquals("Soft windows are returned", SoftWindow.class, reader.getWindow(0).getClass());
+			try(FileReader reader = it.next()) {
+				reader.useSoftWindows(true);
+				assertEquals("Soft windows are returned", SoftWindow.class, reader.getWindow(0).getClass());
+			}
 		}
 	}
 
@@ -386,109 +415,110 @@ public class FileReaderTest {
 	 * Test of getFile method, of class FileReader.
 	 */
 	@Test
-	public void testGetFile() {
+	public void testGetFile() throws IOException {
 		File testFile = getFile("/TestASCII.txt");
 		FileReaderIterator it = new FileReaderIterator("/TestASCII.txt");
 		while (it.hasNext()) {
-			FileReader reader = it.next();
-			assertEquals("Files are correct.", testFile, reader.getFile());
+			try(FileReader reader = it.next()) {
+				assertEquals("Files are correct.", testFile, reader.getFile());
+			}
 		}
 	}
 
 	@Test
 	public void testCreateValidFileAndCache() {
 		File testFile = getFile("/TestASCII.txt");
-		try {
-			FileReader reader = new FileReader(testFile, NoCache.NO_CACHE);
-		} catch (Exception anything) {
+		try( FileReader reader = new FileReader(testFile, NoCache.NO_CACHE)) {
+		}
+		catch (Exception anything) {
 			fail("Should be no exception creating a valid file reader.");
 		}
 	}
 
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testCreateNullFile() throws FileNotFoundException {
-		new FileReader((File) null);
+	public void testCreateNullFile() throws IOException {
+		try(FileReader fr = new FileReader((File) null)) {
+
+		}
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testCreateNullCacheFile() throws FileNotFoundException {
-		new FileReader((File) null, null);
+	public void testCreateNullCacheFile() throws IOException {
+		try(FileReader fr = new FileReader((File) null, null)) {}
 	}
 
 	@Test
 	public void testCreateFileWindowSize() {
 		File testFile = getFile("/TestASCII.txt");
-		try {
-			FileReader reader = new FileReader(testFile, 1024);
+		try(FileReader reader = new FileReader(testFile, 1024)){
 		} catch (Exception e) {
 			fail("Should be no Exception from creating a valid FileReader.");
 		}
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testCreateNullFileWindowSize() throws FileNotFoundException {
-		new FileReader((File) null, 1024);
+	public void testCreateNullFileWindowSize() throws IOException {
+		try(FileReader fr = new FileReader((File) null, 1024)) {}
 	}
 
 	@Test
 	public void testCreateFileWindowSizeCapacity() {
 		File testFile = getFile("/TestASCII.txt");
-		try {
-			FileReader reader = new FileReader(testFile, 1024, 32);
+		try(FileReader reader = new FileReader(testFile, 1024, 32)) {
 		} catch (Exception e) {
 			fail("Should be no Exception from creating a valid FileReader.");
 		}
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testCreateNullFileWindowSizeCapacity() throws FileNotFoundException {
-		new FileReader((File) null, 1024, 32);
+	public void testCreateNullFileWindowSizeCapacity() throws IOException {
+		try(FileReader fr = new FileReader((File) null, 1024, 32)) {}
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testCreateNullPath() throws FileNotFoundException {
-		new FileReader((String) null);
+	public void testCreateNullPath() throws IOException {
+		try(FileReader fr = new FileReader((String) null)) {}
 	}
 
 	@Test
 	public void testCreatePathSize() {
 		String path = getFilePath("/TestASCII.txt");
-		try {
-			FileReader reader = new FileReader(path, 1024);
+		try(FileReader reader = new FileReader(path, 1024)) {
 		} catch (Exception e) {
 			fail("Should be no Exception from creating a valid FileReader.");
 		}
 }
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testCreateNullPathCache() throws FileNotFoundException {
-		new FileReader((String) null, null);
+	public void testCreateNullPathCache() throws IOException {
+		try(FileReader fr = new FileReader((String) null, null)) {}
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testCreatePathNullCache() throws FileNotFoundException {
-		new FileReader("/TestASCII.txt", null);
+	public void testCreatePathNullCache() throws IOException {
+		try(FileReader fr = new FileReader("/TestASCII.txt", null)) {}
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testCreateNullPathWindowSize() throws FileNotFoundException {
-		new FileReader((String) null, 1024);
+	public void testCreateNullPathWindowSize() throws IOException {
+		try(FileReader fr = new FileReader((String) null, 1024)) {}
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testCreateNullPathWindowSizeCapacity() throws FileNotFoundException {
-		new FileReader((String) null, 1024, 32);
+	public void testCreateNullPathWindowSizeCapacity() throws IOException {
+		try(FileReader fr = new FileReader((String) null, 1024, 32)) {}
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testCreateNullFileWindowSizeCache() throws FileNotFoundException {
-		new FileReader((File) null, 1024, null);
+	public void testCreateNullFileWindowSizeCache() throws IOException {
+		try (FileReader fr = new FileReader((File) null, 1024, null)) {
+		}
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testCreateFileWindowSizeNullCache() throws FileNotFoundException {
-		new FileReader(getFile("/TestASCII.txt"), 1024, null);
+	public void testCreateFileWindowSizeNullCache() throws IOException {
+		try(FileReader fr = new FileReader(getFile("/TestASCII.txt"), 1024, null)) {}
 	}
 
 	/*
@@ -527,7 +557,7 @@ public class FileReaderTest {
 	 * constructions, which should make no difference to the functionality of the file reader,
 	 * (except the non-functional requirement of performance).
 	 */
-	private class FileReaderIterator implements Iterator<FileReader> {
+	private class FileReaderIterator implements Iterator<FileReader>{
 
 		private final String	filePath;
 


### PR DESCRIPTION
Great library!  I am looking to integrate byteseek into Apache Metron as a dependency, but sadly you depend on a LGPL library (trove), which isn't a permissive license and against the rules for the Apache Software Foundation.

In this PR, I migrated the library from trove to [org.apache.mahout.mahout-math](https://mvnrepository.com/artifact/org.apache.mahout/mahout-math), which is based on [Colt](https://dst.lbl.gov/ACSSoftware/colt/), under active development and poses no license challenges.

I also corrected a few other small things:
* Github markdown has shifted over the years, so I made the `README.md` conform
* One of the unit tests wasn't cleaning up resources and, as a result, when running all the tests in the same JVM in the IDE, it bombs.

I ran the tests in Intellij and also ran the build in maven with `mvn clean package`.  I figured the test coverage around the trove stuff was pretty well covered, so I didn't add any new tests.